### PR TITLE
Handle Google Sheets API temporary outages gracefully

### DIFF
--- a/src/gsheets/ledger.py
+++ b/src/gsheets/ledger.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import datetime
 from typing import Any
@@ -7,7 +8,11 @@ import gspread
 from dotenv import load_dotenv
 from google.oauth2.service_account import Credentials
 
+from src.gsheets.retry import retry_on_api_error
+
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 SERVICE_ACCOUNT_FILE = os.getenv("GSHEETS_SERVICE_ACCOUNT_FILE")
 SPREADSHEET_ID = os.getenv("GSHEETS_SPREADSHEET_ID")
@@ -35,7 +40,21 @@ def get_gsheets_client():
     return gspread.authorize(creds)
 
 
+@retry_on_api_error()
 def get_worksheet(testing_flag: bool = False):
+    """
+    Get the worksheet from Google Sheets with automatic retry on transient errors.
+
+    Args:
+        testing_flag: If True, uses "Test" worksheet, otherwise "Cuentas"
+
+    Returns:
+        gspread.Worksheet object
+
+    Raises:
+        RuntimeError: If worksheet is not found
+        gspread.exceptions.APIError: If API call fails after retries
+    """
     client = get_gsheets_client()
     sheet = client.open_by_key(SPREADSHEET_ID)
     worksheet_name = "Test" if testing_flag else "Cuentas"
@@ -46,7 +65,20 @@ def get_worksheet(testing_flag: bool = False):
         raise RuntimeError(f"Worksheet '{worksheet_name}' not found.") from None
 
 
+@retry_on_api_error()
 def load_sheet_data(worksheet) -> list[dict[str, Any]]:
+    """
+    Load all data from worksheet with automatic retry on transient errors.
+
+    Args:
+        worksheet: gspread.Worksheet object
+
+    Returns:
+        List of dictionaries, each representing a row with header keys
+
+    Raises:
+        gspread.exceptions.APIError: If API call fails after retries
+    """
     all_values = worksheet.get_all_values()
     if not all_values or len(all_values) < 2:
         return []

--- a/src/gsheets/retry.py
+++ b/src/gsheets/retry.py
@@ -1,0 +1,159 @@
+"""
+Google Sheets API retry utility.
+
+Follows Single Responsibility Principle - handles retry logic for transient API errors.
+Provides decorator for automatic retry with exponential backoff on retryable errors.
+"""
+import functools
+import logging
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TypeVar, cast
+
+import gspread
+
+logger = logging.getLogger(__name__)
+
+# Type variable for generic function return type
+T = TypeVar("T")
+
+# HTTP status codes that indicate transient errors worth retrying
+RETRYABLE_STATUS_CODES = {
+    429,  # Too Many Requests (rate limiting)
+    500,  # Internal Server Error
+    502,  # Bad Gateway
+    503,  # Service Unavailable
+    504,  # Gateway Timeout
+}
+
+
+@dataclass
+class RetryConfig:
+    """
+    Configuration for retry behavior.
+
+    Attributes:
+        max_retries: Maximum number of retry attempts (default: 3)
+        initial_delay: Initial delay in seconds before first retry (default: 1.0)
+        max_delay: Maximum delay in seconds between retries (default: 60.0)
+        exponential_base: Base for exponential backoff calculation (default: 2.0)
+    """
+
+    max_retries: int = 3
+    initial_delay: float = 1.0
+    max_delay: float = 60.0
+    exponential_base: float = 2.0
+
+
+def is_retryable_error(error: Exception) -> bool:
+    """
+    Determine if an error is retryable.
+
+    Args:
+        error: Exception to check
+
+    Returns:
+        True if the error is a transient API error that should be retried,
+        False otherwise
+    """
+    if not isinstance(error, gspread.exceptions.APIError):
+        return False
+
+    try:
+        # Extract status code from APIError
+        # APIError stores response in error.response which has a status_code attribute
+        if hasattr(error, "response") and hasattr(error.response, "status_code"):
+            status_code = error.response.status_code
+            return status_code in RETRYABLE_STATUS_CODES
+
+        # Fallback: try to parse from error args
+        if error.args and isinstance(error.args[0], dict):
+            status_code = error.args[0].get("code")
+            return status_code in RETRYABLE_STATUS_CODES
+
+        return False
+    except (AttributeError, KeyError, IndexError):
+        logger.debug(f"Could not extract status code from error: {error}")
+        return False
+
+
+def retry_on_api_error(
+    config: RetryConfig | None = None,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """
+    Decorator that retries a function on transient Google Sheets API errors.
+
+    Uses exponential backoff with configurable parameters. Only retries on
+    errors that are likely to be transient (503, 429, 500, 502, 504).
+
+    Args:
+        config: Retry configuration. If None, uses default RetryConfig.
+
+    Returns:
+        Decorator function that wraps the target function with retry logic.
+
+    Example:
+        @retry_on_api_error()
+        def get_worksheet():
+            return client.open_by_key(sheet_id)
+
+        @retry_on_api_error(RetryConfig(max_retries=5, initial_delay=2.0))
+        def update_cells(cells):
+            worksheet.update_cells(cells)
+    """
+    if config is None:
+        config = RetryConfig()
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs) -> T:
+            last_error: Exception | None = None
+            delay = config.initial_delay
+
+            for attempt in range(config.max_retries + 1):
+                try:
+                    result = func(*args, **kwargs)
+                    if attempt > 0:
+                        logger.info(
+                            f"Function {func.__name__} succeeded after {attempt} retries"
+                        )
+                    return result
+
+                except Exception as e:
+                    last_error = e
+
+                    # Check if this is the last attempt
+                    if attempt >= config.max_retries:
+                        logger.error(
+                            f"Function {func.__name__} failed after {config.max_retries} retries: {e}"
+                        )
+                        raise
+
+                    # Check if error is retryable
+                    if not is_retryable_error(e):
+                        logger.info(
+                            f"Function {func.__name__} failed with non-retryable error: {e}"
+                        )
+                        raise
+
+                    # Log retry attempt
+                    logger.warning(
+                        f"Function {func.__name__} failed with retryable error: {e}. "
+                        f"Retrying in {delay:.2f}s (attempt {attempt + 1}/{config.max_retries})"
+                    )
+
+                    # Wait before retry
+                    time.sleep(delay)
+
+                    # Calculate next delay with exponential backoff, capped at max_delay
+                    delay = min(delay * config.exponential_base, config.max_delay)
+
+            # This should never be reached, but adding for type safety
+            if last_error:
+                raise last_error
+            raise RuntimeError(f"Function {func.__name__} failed with unknown error")
+
+        return cast(Callable[..., T], wrapper)
+
+    return decorator

--- a/src/gsheets/retry.py
+++ b/src/gsheets/retry.py
@@ -65,13 +65,14 @@ def is_retryable_error(error: Exception) -> bool:
         # Extract status code from APIError
         # APIError stores response in error.response which has a status_code attribute
         if hasattr(error, "response") and hasattr(error.response, "status_code"):
-            status_code = error.response.status_code
+            status_code: int = error.response.status_code
             return status_code in RETRYABLE_STATUS_CODES
 
         # Fallback: try to parse from error args
         if error.args and isinstance(error.args[0], dict):
-            status_code = error.args[0].get("code")
-            return status_code in RETRYABLE_STATUS_CODES
+            status_code_fallback = error.args[0].get("code")
+            if status_code_fallback is not None:
+                return status_code_fallback in RETRYABLE_STATUS_CODES
 
         return False
     except (AttributeError, KeyError, IndexError):

--- a/src/gsheets/retry.py
+++ b/src/gsheets/retry.py
@@ -4,6 +4,7 @@ Google Sheets API retry utility.
 Follows Single Responsibility Principle - handles retry logic for transient API errors.
 Provides decorator for automatic retry with exponential backoff on retryable errors.
 """
+
 import functools
 import logging
 import time

--- a/tests/test_gsheets_retry.py
+++ b/tests/test_gsheets_retry.py
@@ -1,0 +1,403 @@
+"""
+test_gsheets_retry.py
+
+Tests for Google Sheets retry decorator following AAA pattern:
+- Arrange: Set up test data and mocks
+- Act: Execute the function/method being tested
+- Assert: Verify expected behavior
+"""
+from unittest.mock import Mock, patch
+
+import gspread
+import pytest
+
+from src.gsheets.retry import (
+    RetryConfig,
+    is_retryable_error,
+    retry_on_api_error,
+)
+
+
+class TestIsRetryableError:
+    """Tests for is_retryable_error function."""
+
+    def test_retryable_503_service_unavailable(self):
+        """Test that 503 errors are retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 503, "message": "The service is currently unavailable."}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is True
+
+    def test_retryable_429_rate_limit(self):
+        """Test that 429 rate limit errors are retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 429, "message": "Rate limit exceeded"}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is True
+
+    def test_retryable_500_internal_server_error(self):
+        """Test that 500 internal server errors are retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 500, "message": "Internal server error"}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is True
+
+    def test_retryable_502_bad_gateway(self):
+        """Test that 502 bad gateway errors are retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 502, "message": "Bad gateway"}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is True
+
+    def test_retryable_504_gateway_timeout(self):
+        """Test that 504 gateway timeout errors are retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 504, "message": "Gateway timeout"}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is True
+
+    def test_non_retryable_404_not_found(self):
+        """Test that 404 errors are not retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 404, "message": "Not found"}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is False
+
+    def test_non_retryable_400_bad_request(self):
+        """Test that 400 errors are not retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 400, "message": "Bad request"}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is False
+
+    def test_non_retryable_403_forbidden(self):
+        """Test that 403 errors are not retryable."""
+        # Arrange
+        error = gspread.exceptions.APIError(
+            {"code": 403, "message": "Forbidden"}
+        )
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is False
+
+    def test_non_api_error_exception(self):
+        """Test that non-APIError exceptions are not retryable."""
+        # Arrange
+        error = ValueError("Some other error")
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is False
+
+    def test_worksheet_not_found_not_retryable(self):
+        """Test that WorksheetNotFound errors are not retryable."""
+        # Arrange
+        error = gspread.exceptions.WorksheetNotFound("Worksheet not found")
+
+        # Act
+        result = is_retryable_error(error)
+
+        # Assert
+        assert result is False
+
+
+class TestRetryConfig:
+    """Tests for RetryConfig dataclass."""
+
+    def test_default_config(self):
+        """Test default retry configuration values."""
+        # Arrange & Act
+        config = RetryConfig()
+
+        # Assert
+        assert config.max_retries == 3
+        assert config.initial_delay == 1.0
+        assert config.max_delay == 60.0
+        assert config.exponential_base == 2.0
+
+    def test_custom_config(self):
+        """Test custom retry configuration values."""
+        # Arrange & Act
+        config = RetryConfig(
+            max_retries=5,
+            initial_delay=2.0,
+            max_delay=120.0,
+            exponential_base=3.0
+        )
+
+        # Assert
+        assert config.max_retries == 5
+        assert config.initial_delay == 2.0
+        assert config.max_delay == 120.0
+        assert config.exponential_base == 3.0
+
+
+class TestRetryOnApiError:
+    """Tests for retry_on_api_error decorator."""
+
+    def setup_method(self):
+        """Set up test fixtures before each test method."""
+        self.mock_func = Mock()
+
+    def test_success_no_retry_needed(self):
+        """Test successful execution with no retries."""
+        # Arrange
+        self.mock_func.return_value = "success"
+        decorated = retry_on_api_error()(self.mock_func)
+
+        # Act
+        result = decorated()
+
+        # Assert
+        assert result == "success"
+        assert self.mock_func.call_count == 1
+
+    def test_retry_on_503_then_success(self):
+        """Test retry on 503 error followed by success."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 503, "message": "Service unavailable"}
+        )
+        self.mock_func.side_effect = [api_error, "success"]
+        config = RetryConfig(initial_delay=0.01)  # Fast retry for testing
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act
+        result = decorated()
+
+        # Assert
+        assert result == "success"
+        assert self.mock_func.call_count == 2
+
+    def test_retry_multiple_times_then_success(self):
+        """Test multiple retries before success."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 503, "message": "Service unavailable"}
+        )
+        self.mock_func.side_effect = [api_error, api_error, "success"]
+        config = RetryConfig(initial_delay=0.01)
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act
+        result = decorated()
+
+        # Assert
+        assert result == "success"
+        assert self.mock_func.call_count == 3
+
+    def test_max_retries_exceeded(self):
+        """Test that exception is raised when max retries exceeded."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 503, "message": "Service unavailable"}
+        )
+        self.mock_func.side_effect = api_error
+        config = RetryConfig(max_retries=2, initial_delay=0.01)
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act & Assert
+        with pytest.raises(gspread.exceptions.APIError):
+            decorated()
+        assert self.mock_func.call_count == 3  # Initial + 2 retries
+
+    def test_non_retryable_error_no_retry(self):
+        """Test that non-retryable errors are not retried."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 404, "message": "Not found"}
+        )
+        self.mock_func.side_effect = api_error
+        config = RetryConfig(initial_delay=0.01)
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act & Assert
+        with pytest.raises(gspread.exceptions.APIError):
+            decorated()
+        assert self.mock_func.call_count == 1  # No retries
+
+    def test_non_api_error_no_retry(self):
+        """Test that non-API errors are not retried."""
+        # Arrange
+        self.mock_func.side_effect = ValueError("Some error")
+        config = RetryConfig(initial_delay=0.01)
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act & Assert
+        with pytest.raises(ValueError):
+            decorated()
+        assert self.mock_func.call_count == 1  # No retries
+
+    @patch("time.sleep")
+    def test_exponential_backoff_delays(self, mock_sleep):
+        """Test that exponential backoff delays are applied correctly."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 503, "message": "Service unavailable"}
+        )
+        self.mock_func.side_effect = [api_error, api_error, api_error, "success"]
+        config = RetryConfig(
+            max_retries=3,
+            initial_delay=1.0,
+            exponential_base=2.0
+        )
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act
+        result = decorated()
+
+        # Assert
+        assert result == "success"
+        assert self.mock_func.call_count == 4
+        # Verify exponential backoff: 1.0, 2.0, 4.0
+        assert mock_sleep.call_count == 3
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert delays[0] == pytest.approx(1.0, rel=0.1)
+        assert delays[1] == pytest.approx(2.0, rel=0.1)
+        assert delays[2] == pytest.approx(4.0, rel=0.1)
+
+    @patch("time.sleep")
+    def test_max_delay_cap(self, mock_sleep):
+        """Test that delay is capped at max_delay."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 503, "message": "Service unavailable"}
+        )
+        self.mock_func.side_effect = [api_error, api_error, "success"]
+        config = RetryConfig(
+            max_retries=3,
+            initial_delay=50.0,
+            max_delay=60.0,
+            exponential_base=2.0
+        )
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act
+        result = decorated()
+
+        # Assert
+        assert result == "success"
+        # First delay: 50.0, second delay: min(100.0, 60.0) = 60.0
+        delays = [call.args[0] for call in mock_sleep.call_args_list]
+        assert delays[0] == pytest.approx(50.0, rel=0.1)
+        assert delays[1] == pytest.approx(60.0, rel=0.1)  # Capped at max_delay
+
+    def test_decorator_preserves_function_metadata(self):
+        """Test that decorator preserves original function metadata."""
+        # Arrange
+        def sample_function():
+            """Sample docstring."""
+            return "result"
+
+        # Act
+        decorated = retry_on_api_error()(sample_function)
+
+        # Assert
+        assert decorated.__name__ == "sample_function"
+        assert decorated.__doc__ == "Sample docstring."
+
+    def test_decorator_with_args_and_kwargs(self):
+        """Test that decorator works with functions that have arguments."""
+        # Arrange
+        def add_numbers(a: int, b: int, multiplier: int = 1) -> int:
+            return (a + b) * multiplier
+
+        api_error = gspread.exceptions.APIError(
+            {"code": 503, "message": "Service unavailable"}
+        )
+        mock_func = Mock(side_effect=[api_error, 15])
+        mock_func.__name__ = "add_numbers"
+        mock_func.__doc__ = "Adds numbers"
+
+        config = RetryConfig(initial_delay=0.01)
+        decorated = retry_on_api_error(config)(mock_func)
+
+        # Act
+        result = decorated(5, 3, multiplier=2)
+
+        # Assert
+        assert result == 15
+        assert mock_func.call_count == 2
+        # Verify args were passed correctly
+        mock_func.assert_called_with(5, 3, multiplier=2)
+
+    def test_retry_on_429_rate_limit(self):
+        """Test retry on 429 rate limit error."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 429, "message": "Rate limit exceeded"}
+        )
+        self.mock_func.side_effect = [api_error, "success"]
+        config = RetryConfig(initial_delay=0.01)
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act
+        result = decorated()
+
+        # Assert
+        assert result == "success"
+        assert self.mock_func.call_count == 2
+
+    def test_retry_on_500_internal_server_error(self):
+        """Test retry on 500 internal server error."""
+        # Arrange
+        api_error = gspread.exceptions.APIError(
+            {"code": 500, "message": "Internal server error"}
+        )
+        self.mock_func.side_effect = [api_error, "success"]
+        config = RetryConfig(initial_delay=0.01)
+        decorated = retry_on_api_error(config)(self.mock_func)
+
+        # Act
+        result = decorated()
+
+        # Assert
+        assert result == "success"
+        assert self.mock_func.call_count == 2

--- a/tests/test_gsheets_retry.py
+++ b/tests/test_gsheets_retry.py
@@ -6,6 +6,7 @@ Tests for Google Sheets retry decorator following AAA pattern:
 - Act: Execute the function/method being tested
 - Assert: Verify expected behavior
 """
+
 from unittest.mock import Mock, patch
 
 import gspread
@@ -63,9 +64,7 @@ class TestIsRetryableError:
     def test_retryable_502_bad_gateway(self):
         """Test that 502 bad gateway errors are retryable."""
         # Arrange
-        error = gspread.exceptions.APIError(
-            {"code": 502, "message": "Bad gateway"}
-        )
+        error = gspread.exceptions.APIError({"code": 502, "message": "Bad gateway"})
 
         # Act
         result = is_retryable_error(error)
@@ -76,9 +75,7 @@ class TestIsRetryableError:
     def test_retryable_504_gateway_timeout(self):
         """Test that 504 gateway timeout errors are retryable."""
         # Arrange
-        error = gspread.exceptions.APIError(
-            {"code": 504, "message": "Gateway timeout"}
-        )
+        error = gspread.exceptions.APIError({"code": 504, "message": "Gateway timeout"})
 
         # Act
         result = is_retryable_error(error)
@@ -89,9 +86,7 @@ class TestIsRetryableError:
     def test_non_retryable_404_not_found(self):
         """Test that 404 errors are not retryable."""
         # Arrange
-        error = gspread.exceptions.APIError(
-            {"code": 404, "message": "Not found"}
-        )
+        error = gspread.exceptions.APIError({"code": 404, "message": "Not found"})
 
         # Act
         result = is_retryable_error(error)
@@ -102,9 +97,7 @@ class TestIsRetryableError:
     def test_non_retryable_400_bad_request(self):
         """Test that 400 errors are not retryable."""
         # Arrange
-        error = gspread.exceptions.APIError(
-            {"code": 400, "message": "Bad request"}
-        )
+        error = gspread.exceptions.APIError({"code": 400, "message": "Bad request"})
 
         # Act
         result = is_retryable_error(error)
@@ -115,9 +108,7 @@ class TestIsRetryableError:
     def test_non_retryable_403_forbidden(self):
         """Test that 403 errors are not retryable."""
         # Arrange
-        error = gspread.exceptions.APIError(
-            {"code": 403, "message": "Forbidden"}
-        )
+        error = gspread.exceptions.APIError({"code": 403, "message": "Forbidden"})
 
         # Act
         result = is_retryable_error(error)
@@ -166,10 +157,7 @@ class TestRetryConfig:
         """Test custom retry configuration values."""
         # Arrange & Act
         config = RetryConfig(
-            max_retries=5,
-            initial_delay=2.0,
-            max_delay=120.0,
-            exponential_base=3.0
+            max_retries=5, initial_delay=2.0, max_delay=120.0, exponential_base=3.0
         )
 
         # Assert
@@ -251,9 +239,7 @@ class TestRetryOnApiError:
     def test_non_retryable_error_no_retry(self):
         """Test that non-retryable errors are not retried."""
         # Arrange
-        api_error = gspread.exceptions.APIError(
-            {"code": 404, "message": "Not found"}
-        )
+        api_error = gspread.exceptions.APIError({"code": 404, "message": "Not found"})
         self.mock_func.side_effect = api_error
         config = RetryConfig(initial_delay=0.01)
         decorated = retry_on_api_error(config)(self.mock_func)
@@ -283,11 +269,7 @@ class TestRetryOnApiError:
             {"code": 503, "message": "Service unavailable"}
         )
         self.mock_func.side_effect = [api_error, api_error, api_error, "success"]
-        config = RetryConfig(
-            max_retries=3,
-            initial_delay=1.0,
-            exponential_base=2.0
-        )
+        config = RetryConfig(max_retries=3, initial_delay=1.0, exponential_base=2.0)
         decorated = retry_on_api_error(config)(self.mock_func)
 
         # Act
@@ -312,10 +294,7 @@ class TestRetryOnApiError:
         )
         self.mock_func.side_effect = [api_error, api_error, "success"]
         config = RetryConfig(
-            max_retries=3,
-            initial_delay=50.0,
-            max_delay=60.0,
-            exponential_base=2.0
+            max_retries=3, initial_delay=50.0, max_delay=60.0, exponential_base=2.0
         )
         decorated = retry_on_api_error(config)(self.mock_func)
 
@@ -331,6 +310,7 @@ class TestRetryOnApiError:
 
     def test_decorator_preserves_function_metadata(self):
         """Test that decorator preserves original function metadata."""
+
         # Arrange
         def sample_function():
             """Sample docstring."""
@@ -345,6 +325,7 @@ class TestRetryOnApiError:
 
     def test_decorator_with_args_and_kwargs(self):
         """Test that decorator works with functions that have arguments."""
+
         # Arrange
         def add_numbers(a: int, b: int, multiplier: int = 1) -> int:
             return (a + b) * multiplier

--- a/update_gsheets.py
+++ b/update_gsheets.py
@@ -1,15 +1,19 @@
 import argparse
-import os
+import logging
 from datetime import datetime
 from decimal import Decimal
 from zoneinfo import ZoneInfo
 
-import gspread
 from dotenv import load_dotenv
-from google.oauth2.service_account import Credentials
 
+from src.gsheets.ledger import datetime_to_gs_serial, get_worksheet, load_sheet_data
+from src.gsheets.retry import retry_on_api_error
 from src.ynab.reader import get_consolidated_ynab_entries
 from src.ynab.ynab_types import YNABEntry
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 # --- SETUP INSTRUCTIONS ---
 # 1. Install dependencies: pip install gspread google-auth python-dotenv
@@ -17,32 +21,6 @@ from src.ynab.ynab_types import YNABEntry
 # 3. Share your Google Sheet with the service account email (from the JSON file) as Editor.
 # 4. Place the JSON key file in your secrets folder and set its path in your .env file.
 # 5. Set GSHEETS_SPREADSHEET_ID in your .env file to your target Google Sheet's ID (from its URL).
-
-load_dotenv()
-SERVICE_ACCOUNT_FILE = os.getenv(
-    "GSHEETS_SERVICE_ACCOUNT_FILE"
-)  # Path to your service account key file
-SPREADSHEET_ID = os.getenv("GSHEETS_SPREADSHEET_ID")  # Google Sheet ID
-# https://docs.google.com/spreadsheets/d/1MLs3H1L1rFtORvtnnoc8HmOdM9jmWsW0PyjqYrfoZKM/edit?gid=239521179#gid=239521179
-
-# Define the required scopes
-SCOPES = [
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/drive",
-]
-
-HEADER_COLUMNS = [
-    "ID",
-    "Cuenta",
-    "Saldo",
-    "YNAB",
-    "Diff",
-    "Tipo Cuenta",
-    "Fecha Corte",
-    "Fecha Pago",
-    "Ultima Actualizacion",
-    "Cuenta YNAB",
-]
 
 
 def parse_args():
@@ -53,40 +31,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_gsheets_client():
-    creds = Credentials.from_service_account_file(SERVICE_ACCOUNT_FILE, scopes=SCOPES)
-    return gspread.authorize(creds)
-
-
-def get_working_worksheet(sheet, testing_flag):
-    worksheet_name = "Test" if testing_flag else "Cuentas"
-    try:
-        worksheet = sheet.worksheet(worksheet_name)
-        return worksheet
-    except gspread.exceptions.WorksheetNotFound:
-        print(f"Worksheet '{worksheet_name}' not found.")
-        exit(1)
-
-
-def load_sheet_data(worksheet):
-    # Get all values
-    all_values = worksheet.get_all_values()
-    if not all_values or len(all_values) < 2:
-        return []
-    header = all_values[0]
-    data_rows = all_values[1:]
-    # Map each row to a dict using the header
-    data = [dict(zip(header, row, strict=False)) for row in data_rows]
-    return data
-
-
-def datetime_to_gs_serial(dt: datetime) -> float:
-    """Convert a timezone-aware datetime to Google Sheets serial number."""
-    gs_epoch = datetime(1899, 12, 30, tzinfo=ZoneInfo("America/Mexico_City"))
-    delta = dt - gs_epoch
-    return delta.days + delta.seconds / 86400 + delta.microseconds / 86400 / 1e6
-
-
+@retry_on_api_error()
 def update_ynab_balances(sheet_data, updates: list[YNABEntry], worksheet) -> list[str]:
     """
     Updates the 'YNAB' column in the worksheet for rows where 'Cuenta' matches the 'name' in updates.
@@ -134,23 +79,26 @@ def update_ynab_balances(sheet_data, updates: list[YNABEntry], worksheet) -> lis
 
 def main():
     args = parse_args()
-    client = get_gsheets_client()
-    sheet = client.open_by_key(SPREADSHEET_ID)
-    worksheet = get_working_worksheet(sheet, args.testing)
+    worksheet = get_worksheet(testing_flag=args.testing)
     data = load_sheet_data(worksheet)
 
     updates = get_consolidated_ynab_entries()
     if updates:
         updated_names = update_ynab_balances(data, updates, worksheet)
+        logger.info(f"Updated {len(updated_names)} YNAB balances.")
         print(f"Updated {len(updated_names)} YNAB balances.")
         all_update_names = {entry["name"] for entry in updates}
         updated_names_set = set(updated_names)
         not_updated = all_update_names - updated_names_set
         if not_updated:
+            logger.warning(
+                f"The following YNAB balances could not be updated in the sheet: {sorted(not_updated)}"
+            )
             print("The following YNAB balances could not be updated in the sheet:")
             for name in sorted(not_updated):
                 print(f"- {name}")
     else:
+        logger.info("No consolidated YNAB balances available.")
         print("No consolidated YNAB balances available.")
 
 


### PR DESCRIPTION
Implements automatic retry with exponential backoff for transient Google Sheets API errors (503, 429, 500, 502, 504).

Changes:
- Add retry decorator utility (src/gsheets/retry.py) with configurable retry behavior following SRP and testability principles
- Apply retry logic to all Google Sheets API calls in ledger.py
- Refactor update_gsheets.py to use ledger.py functions (DRY)
- Add comprehensive unit tests for retry logic
- Add proper logging throughout Google Sheets operations

This resolves the issue where the daily YNAB Google Sheets Update job fails with "503: The service is currently unavailable" errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience to transient Google Sheets API failures (rate limits and server errors) via automatic retries.

* **Refactor**
  * Reorganized Google Sheets handling into modular utilities and centralized retry logic; added richer logging and runtime notices for operations and updates.

* **Tests**
  * Added comprehensive unit tests for retry behavior, backoff timing, and error-handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->